### PR TITLE
Update Vite version to 5.0.12

### DIFF
--- a/conversational-therapy-ai/frontend/chatflow 7/package.json
+++ b/conversational-therapy-ai/frontend/chatflow 7/package.json
@@ -11,8 +11,7 @@
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^3.1.0",
     "typescript": "^4.9.3",
-    "vite": "^4.2.0"
-  },
+    "vite": "^5.0.12"  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
Fixes multiple Dependabot security alerts for Vite:
- Server.fs.deny bypass via backslash on Windows
- Vite middleware serving files with same public directory name
- Vite server.fs settings not applied to HTML files

Updates from 4.2.0 to 5.0.12 to address all known vulnerabilities.